### PR TITLE
Condition on R version so that also older version of R remain supported

### DIFF
--- a/pkg/muste/DESCRIPTION
+++ b/pkg/muste/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: muste
 Type: Package
 Title: General Editorial Computing Environment for Data Analysis
-Version: 0.8.1
-Date: 2026-07-08
+Version: 0.8.2
+Date: 2026-07-09
 Author: Reijo Sund [aut, cre], Seppo Mustonen [aut], Kimmo Vehkalahti [aut]
 Maintainer: Reijo Sund <reijo.sund@uef.fi>
 Description: Survo R is an open source version of the

--- a/pkg/muste/src/muste.c
+++ b/pkg/muste/src/muste.c
@@ -128,8 +128,17 @@ int muste_checkstack(void)
    return(1);
 }
 */
+#include <Rversion.h>
+
+#define MUSTE_R_VERSION(maj, min, pat) (((maj) << 16) + ((min) << 8) + (pat))
 
 SEXP muste_findVar(SEXP sym, SEXP env) {
+#if R_VERSION < MUSTE_R_VERSION(4, 5, 0)
+
+    return Rf_findVar(sym, env);
+
+#else
+
     while (env != R_EmptyEnv) {
         if (R_existsVarInFrame(env, sym)) {
             return R_getVar(sym, env, FALSE);
@@ -139,6 +148,8 @@ SEXP muste_findVar(SEXP sym, SEXP env) {
     }
 
     return R_UnboundValue;
+
+#endif
 }
 
 int muste_is_utf8_string(SEXP x) {


### PR DESCRIPTION
Recent R API changes required some changes in how to implement certain functionality. As Rf_findVar() became hidden that had to be replaced with new API calls that are not available in older R versions meaning that calls to those are not working and the package won't compile. That should not happen as many users may still be using older R versions, so findVar-functionality is now conditioned on R version < 0.4.5.